### PR TITLE
Make index_name configurable

### DIFF
--- a/spa/middleware.py
+++ b/spa/middleware.py
@@ -13,7 +13,7 @@ class SPAMiddleware(WhiteNoiseMiddleware):
     with frontend routing on /
 
     """
-    config_attrs = WhiteNoiseMiddleware.config_attrs + ('index_name')
+    config_attrs = WhiteNoiseMiddleware.config_attrs + ('index_name',)
     index_name = 'static/index.html'
 
     def process_request(self, request):

--- a/spa/middleware.py
+++ b/spa/middleware.py
@@ -13,6 +13,7 @@ class SPAMiddleware(WhiteNoiseMiddleware):
     with frontend routing on /
 
     """
+    config_attrs = WhiteNoiseMiddleware.config_attrs + ('index_name')
     index_name = 'static/index.html'
 
     def process_request(self, request):


### PR DESCRIPTION
This PR adds `index_name` to the `WhiteNoiseMiddleware.config_attrs` object. This allows you to set the value of `index_name` within Django's `settings.py` when using a custom static root / url.

For example:

```python
# Static files (CSS, JavaScript, Images)
# https://docs.djangoproject.com/en/2.2/howto/static-files/

STATIC_URL = '/assets/'
STATIC_ROOT = os.path.join(BASE_DIR, 'assets')

STATICFILES_STORAGE = 'spa.storage.SPAStaticFilesStorage'

WHITENOISE_INDEX_NAME = 'assets/index.html'
```

Connects #43 

---

**Testing**

TBD.