### PR TITLE
Update setup.py to require whitenoise 5.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'whitenoise==5.0.1'
+    'whitenoise==5.3.0'
 ]
 
 test_requirements = [
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='django-spa',
-    version='0.3.5',
+    version='0.3.6',
     description="Simple Django configuration to serve a single-page app",
     long_description=readme + '\n\n' + history,
     author="Dražen Lučanin",


### PR DESCRIPTION
As per Whitenoise changelog (http://whitenoise.evans.io/en/stable/changelog.html) no breaking changes prevent updating the dependency. It would be great to prevent pip from fussing about installing a whitenoise version newer than 5.0.1