### PR TITLE
Updated dependency on Whitenoise to version 6.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.5
+current_version = 0.3.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'whitenoise==5.3.0'
+    'whitenoise==6.2.0'
 ]
 
 test_requirements = [
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='django-spa',
-    version='0.3.6',
+    version='0.3.7',
     description="Simple Django configuration to serve a single-page app",
     long_description=readme + '\n\n' + history,
     author="Dražen Lučanin",

--- a/spa/__init__.py
+++ b/spa/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dražen Lučanin"""
 __email__ = 'kermit666@gmail.com'
-__version__ = '0.3.5'
+__version__ = '0.3.7'


### PR DESCRIPTION
After testing on my own project, I found no incompatibilities between django-spa and version 6.2.0 of whitenoise